### PR TITLE
Change ejson format to use version key instead of code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,2 @@
 source "https://rubygems.org/"
 gemspec
-
-group :test do
-  gem "bson"
-  gem "rspec"
-end

--- a/lib/types/version.rb
+++ b/lib/types/version.rb
@@ -19,7 +19,7 @@ module Apptentive
 
     # (E)JSON serialization
     def as_json(*)
-      { _type: "version", code: @code.join(".") }.as_json
+      { _type: "version", version: @code.join(".") }.as_json
     end
 
     def self.is_ejson?(json)
@@ -27,10 +27,10 @@ module Apptentive
     end
 
     def self.from_ejson(ejson)
-      unless ejson.keys.sort == %w(_type code)
+      unless ejson.keys.sort == %w(_type version)
         raise ArgumentError, "Invalid Version json: #{ejson.inspect}"
       end
-      new(ejson["code"])
+      new(ejson["version"])
     end
 
     # MongoDB serialization

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -1,5 +1,4 @@
 require "spec_helper"
-require "types/ejson"
 require "types/version"
 
 RSpec.describe Apptentive::Version do

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+require "types/ejson"
+require "types/version"
+
+RSpec.describe Apptentive::Version do
+  describe "new version" do
+    describe "validation" do
+      context "when the version is a decimal-separated list of integers" do
+        {
+          "1.2.3" => [1, 2, 3],
+          "60000" => [60000]
+        }.each do |ver, code|
+          it "successfully sets up the object" do
+            version = Apptentive::Version.new(ver)
+            expect(version.code).to eq code
+          end
+        end
+      end
+    end
+  end
+
+  describe "#as_ejson" do
+    let(:version) { Apptentive::Version.new("1.2.3") }
+
+    it "outputs version JSON" do
+      expect(version.as_ejson).to eq({ _type: "version", version: "1.2.3" }.as_json)
+    end
+  end
+end

--- a/types.gemspec
+++ b/types.gemspec
@@ -14,4 +14,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activesupport", "~> 3.2.22"
   s.add_dependency "json"
+
+  s.add_development_dependency "rspec"
 end

--- a/types.gemspec
+++ b/types.gemspec
@@ -16,4 +16,5 @@ Gem::Specification.new do |s|
   s.add_dependency "json"
 
   s.add_development_dependency "rspec"
+  s.add_development_dependency "bson"
 end


### PR DESCRIPTION
The spec on the wiki requires a `version` key, but the old code here was expecting a `code` key. This switches us to use the new format.

I started to write additional validation tests and even wanted to tweak the regex for validation, but held off in favor of getting out this minimal change to @MatthewCallis. I'll make an issue to come back and work on that.

PLATFORM-786

@msaffitz @robotblake @jwfearn @cmorss @MatthewCallis 