### PR TITLE
Require version regex to match whole string, including line breaks.

### DIFF
--- a/lib/types/version.rb
+++ b/lib/types/version.rb
@@ -6,10 +6,10 @@ module Apptentive
     attr_accessor :code
 
     def initialize(code)
-      if /(?<ver>\d+(\.\d+)*)/ =~ code
+      if /\A(?<ver>\d+(\.\d+)*)\z/ =~ code
         @code = ver.split(".").map(&:to_i)
       else
-        raise ArgumentError, "Invalid Version: #{code.inspect}"
+        raise ArgumentError, "Invalid Version: '#{code}'"
       end
     end
 

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -15,6 +15,20 @@ RSpec.describe Apptentive::Version do
           end
         end
       end
+
+      context "when the version is invalid" do
+        [
+          "my_version",
+          "1.2.",
+          "1.2-test",
+          ".0",
+          "1.2.3\nhello"
+        ].each do |ver, code|
+          it "(#{ver}) raises and exception" do
+            expect { Apptentive::Version.new(ver) }.to raise_error(ArgumentError, "Invalid Version: '#{ver}'")
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Require version regex to match whole string, including line breaks.
Add tests to validation code.