### PR TITLE
Coerce version to string

### DIFF
--- a/lib/types/version.rb
+++ b/lib/types/version.rb
@@ -6,7 +6,7 @@ module Apptentive
     attr_accessor :code
 
     def initialize(code)
-      if /\A(?<ver>\d+(\.\d+)*)\z/ =~ code
+      if /\A(?<ver>\d+(\.\d+)*)\z/ =~ code.to_s
         @code = ver.split(".").map(&:to_i)
       else
         raise ArgumentError, "Invalid Version: '#{code}'"

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -4,10 +4,11 @@ require "types/version"
 RSpec.describe Apptentive::Version do
   describe "new version" do
     describe "validation" do
-      context "when the version is a decimal-separated list of integers" do
+      context "when the version is a decimal-separated list of integers or a fixnum" do
         {
           "1.2.3" => [1, 2, 3],
-          "60000" => [60000]
+          "60000" => [60000],
+          1 => [1]
         }.each do |ver, code|
           it "successfully sets up the object" do
             version = Apptentive::Version.new(ver)


### PR DESCRIPTION
This fixes an issue where we have version criteria stored as a single fixnum.

@msaffitz @stim371 @jwfearn 